### PR TITLE
Feature assignment index tracking

### DIFF
--- a/bundle/src/main/java/com/meltmedia/dropwizard/etcd/cluster/ClusterAssignmentTracker.java
+++ b/bundle/src/main/java/com/meltmedia/dropwizard/etcd/cluster/ClusterAssignmentTracker.java
@@ -1,0 +1,150 @@
+package com.meltmedia.dropwizard.etcd.cluster;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.meltmedia.dropwizard.etcd.json.EtcdEvent;
+import com.meltmedia.dropwizard.etcd.json.EtcdJson.MappedEtcdDirectory;
+import com.meltmedia.dropwizard.etcd.json.WatchService;
+
+/**
+ * Tracks the state of assignments in the system.
+ * 
+ * @author Christian Trimble
+ */
+public class ClusterAssignmentTracker {
+  public static final String ASSIGNED = "assigned";
+  public static final String UNASSIGNED = "unassigned";
+  public static final String TOTAL = "total";
+
+  public static class AssignmentState {
+    final int totalProcessCount;
+    final int nodeProcessCount;
+    final int unassignedProcessCount;
+    final long etcdIndex;
+    final ClusterNode node;
+    final Map<String, Set<String>> processes;
+    final Set<String> unassigned;
+    
+    AssignmentState( ClusterNode node, long etcdIndex, Map<String, Set<String>> processes, Set<String> unassigned, int totalProcessCount, int nodeProcessCount, int unassignedProcessCount ) {
+      this.node = node;
+      this.etcdIndex = etcdIndex;
+      this.processes = Collections.unmodifiableMap(processes);
+      this.unassigned = Collections.unmodifiableSet(unassigned);
+      this.totalProcessCount = totalProcessCount;
+      this.nodeProcessCount = nodeProcessCount;
+      this.unassignedProcessCount = unassignedProcessCount;
+    }
+    
+    public AssignmentState addProcess(long etcdIndex, String key, ClusterProcess process) {
+      Optional<String> assignedTo = assignedToKey(process);
+      int totalProcessCount = this.totalProcessCount + 1;
+      int nodeProcessCount = this.nodeProcessCount + assignedTo.filter(node.getId()::equals).map(s->1).orElse(0);
+      int unassignedProcessCount = this.unassignedProcessCount + assignedTo.map(s->0).orElse(1);
+      Map<String, Set<String>> processes = Maps.newHashMap(this.processes);
+      Set<String> unassigned = Sets.newHashSet(this.unassigned);
+      if( assignedTo.isPresent() ) {
+        processes.computeIfPresent(assignedTo.get(), (k, v) -> {
+          Set<String> ids = Sets.newHashSet(v);
+          ids.add(key);
+          return ids.isEmpty() ? null : ids;
+        });
+        processes.computeIfAbsent(assignedTo.get(), k->Sets.newHashSet(key));
+      }
+      else {
+        unassigned.add(key);
+      }
+      return new AssignmentState(node, etcdIndex, processes, unassigned, totalProcessCount, nodeProcessCount, unassignedProcessCount );
+    }
+    
+    public AssignmentState removeProcess( long etcdIndex, String key, ClusterProcess process ) {
+      Optional<String> assignedTo = assignedToKey(process);
+      int totalProcessCount = this.totalProcessCount - 1;
+      int nodeProcessCount = this.nodeProcessCount - assignedTo.filter(node.getId()::equals).map(s->1).orElse(0);
+      int unassignedProcessCount = this.unassignedProcessCount - assignedTo.map(s->0).orElse(1);
+      Map<String, Set<String>> processes = Maps.newHashMap(this.processes);
+      Set<String> unassigned = Sets.newHashSet(this.unassigned);
+      if( assignedTo.isPresent() ) {
+        processes.computeIfPresent(assignedTo.get(), (k, v) -> {
+          Set<String> ids = Sets.newHashSet(v);
+          ids.remove(key);
+          return ids.isEmpty() ? null : ids;
+        });
+      }
+      else {
+        unassigned.remove(key);
+      }
+      return new AssignmentState(node, etcdIndex, processes, unassigned, totalProcessCount, nodeProcessCount, unassignedProcessCount );
+    }
+
+    public int nodeProcessCount() {
+      return nodeProcessCount;
+    }
+
+    public int totalProcessCount() {
+      return totalProcessCount;
+    }
+
+    public int unassignedProcessCount() {
+      return unassignedProcessCount;
+    }
+  }
+
+  static Optional<String> assignedToKey(ClusterProcess process) {
+    return Optional.ofNullable(process.getAssignedTo());
+  }
+  
+  private volatile AssignmentState state;
+  MappedEtcdDirectory<ClusterProcess> processDir;
+  WatchService.Watch jobsWatch;
+  MetricRegistry registry;
+  Function<String, String> metricName;
+  
+  public ClusterAssignmentTracker( ClusterNode node, MappedEtcdDirectory<ClusterProcess> processDir, MetricRegistry registry, Function<String, String> metricName ) {
+    state = new AssignmentState(node, 0, Collections.emptyMap(), Collections.emptySet(), 0, 0, 0);
+    this.registry = registry;
+    this.metricName = metricName;
+    this.processDir = processDir;
+  }
+  
+  public AssignmentState getState() {
+    return state;
+  }
+  
+  public void handleProcess(EtcdEvent<ClusterProcess> event) {
+    switch (event.getType()) {
+      case added:
+        state = state.addProcess(event.getIndex(), event.getKey(), event.getValue());
+        break;
+      case updated:
+        state = state
+          .removeProcess(event.getIndex(), event.getKey(), event.getPrevValue())
+          .addProcess(event.getIndex(), event.getKey(), event.getValue());
+        break;
+      case removed:
+        state = state.removeProcess(event.getIndex(), event.getKey(), event.getPrevValue());
+        break;
+    }
+  }
+
+  public void start() {
+    registry.register(metricName.apply(TOTAL), (Gauge<Integer>)()->state.totalProcessCount);
+    registry.register(metricName.apply(ASSIGNED), (Gauge<Integer>)()->state.nodeProcessCount);
+    registry.register(metricName.apply(UNASSIGNED), (Gauge<Integer>)()->state.unassignedProcessCount);
+    jobsWatch = processDir.registerWatch(this::handleProcess);
+  }
+
+  public void stop() {
+    jobsWatch.stop();
+    registry.remove(metricName.apply(UNASSIGNED));
+    registry.remove(metricName.apply(ASSIGNED));
+    registry.remove(metricName.apply(TOTAL));
+  }
+}

--- a/bundle/src/main/java/com/meltmedia/dropwizard/etcd/cluster/ClusterProcessor.java
+++ b/bundle/src/main/java/com/meltmedia/dropwizard/etcd/cluster/ClusterProcessor.java
@@ -18,13 +18,12 @@ package com.meltmedia.dropwizard.etcd.cluster;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
 
-import com.google.common.collect.Maps;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Maps;
 import com.meltmedia.dropwizard.etcd.json.EtcdEvent;
 import com.meltmedia.dropwizard.etcd.json.EtcdJson.MappedEtcdDirectory;
 import com.meltmedia.dropwizard.etcd.json.WatchService;

--- a/bundle/src/main/java/com/meltmedia/dropwizard/etcd/cluster/ProcessorStateTracker.java
+++ b/bundle/src/main/java/com/meltmedia/dropwizard/etcd/cluster/ProcessorStateTracker.java
@@ -1,0 +1,168 @@
+package com.meltmedia.dropwizard.etcd.cluster;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Objects;
+import java.util.SortedSet;
+import java.util.function.BiFunction;
+
+import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Ordering;
+import com.google.common.collect.Sets;
+import com.meltmedia.dropwizard.etcd.json.EtcdEvent;
+import com.meltmedia.dropwizard.etcd.json.EtcdJson.MappedEtcdDirectory;
+import com.meltmedia.dropwizard.etcd.json.WatchService.Watch;
+
+public class ProcessorStateTracker {
+  private static Logger logger = LoggerFactory.getLogger(ProcessorStateTracker.class);
+  public static class Builder {
+    private MappedEtcdDirectory<ProcessorNode> directory;
+    private ClusterNode thisNode;
+
+    public Builder withDirectory(MappedEtcdDirectory<ProcessorNode> directory) {
+      this.directory = directory;
+      return this;
+    }
+
+    public Builder withThisNode(ClusterNode thisNode) {
+      this.thisNode = thisNode;
+      return this;
+    }
+
+    public ProcessorStateTracker build() {
+      return new ProcessorStateTracker(directory, thisNode);
+    }
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  private MappedEtcdDirectory<ProcessorNode> directory;
+  private Watch watch;
+  private volatile ProcessorState state;
+  private ClusterNode thisNode;
+  
+  private ProcessorStateTracker(MappedEtcdDirectory<ProcessorNode> directory, ClusterNode thisNode) {
+    this.directory = directory;
+    this.state = ProcessorState.empty();
+    this.thisNode = thisNode;
+  }
+  
+  public Runnable start( Runnable startWithTracker ) {
+    return ()->{
+      watch = directory.registerWatch(this::handle);
+      try {
+        startWithTracker.run();
+      } finally {
+        publishNode();
+      }
+    };
+  }
+
+  public Runnable stop(Runnable stopWithTracker) {
+    return ()->{
+      unpublishNode();
+      try {
+        stopWithTracker.run();
+      } finally {
+        watch.stop();
+      }
+    };
+  }
+  
+  public ProcessorState getState() {
+    return state;
+  }
+
+  public void handle(EtcdEvent<ProcessorNode> event) {
+    switch (event.getType()) {
+      case added:
+        state = state.addProcessor(event.getIndex(), event.getValue());
+        break;
+      case removed:
+        state = state.removeProcessor(event.getIndex(), event.getPrevValue());
+        break;
+      case updated:
+        state = state.removeProcessor(event.getIndex(), event.getPrevValue()).addProcessor(event.getIndex(), event.getValue());
+        break;
+    }
+  }
+  
+  public static class ProcessorState {
+    private static Comparator<ProcessorNode> COMPARATOR = Ordering.<ProcessorNode> from(
+      (n1, n2) -> Objects.compare(n1.getStartedAt(), n2.getStartedAt(), Ordering.natural()))
+      .compound((n1, n2) -> Objects.compare(n1.getId(), n2.getId(), Ordering.natural()));
+
+    public static ProcessorState empty() {
+      return new ProcessorState(0, Collections.emptySortedSet());
+    }
+    
+    public static ProcessorState empty( long lastModifiedIndex ) {
+      return new ProcessorState(lastModifiedIndex, Collections.emptySortedSet());
+    }
+    
+    private SortedSet<ProcessorNode> processors;
+    private final long lastModifiedIndex;
+
+    private ProcessorState(long lastModifiedIndex, SortedSet<ProcessorNode> processors) {
+      this.lastModifiedIndex = lastModifiedIndex;
+      this.processors = processors;
+    }
+
+    public ProcessorState addProcessor(long lastModifiedIndex, ProcessorNode newProcessor) {
+      return new ProcessorState(lastModifiedIndex, newProcessors(newProcessor, SortedSet::add));
+    }
+
+    public ProcessorState removeProcessor(long lastModfiedIndex, ProcessorNode oldProcessor) {
+      return new ProcessorState(lastModifiedIndex, newProcessors(oldProcessor, SortedSet::remove));
+    }
+
+    private SortedSet<ProcessorNode> newProcessors(ProcessorNode changingMember,
+      BiFunction<SortedSet<ProcessorNode>, ProcessorNode, Boolean> action) {
+      SortedSet<ProcessorNode> newProcessors = Sets.newTreeSet(COMPARATOR);
+      newProcessors.addAll(processors);
+      action.apply(newProcessors, changingMember);
+      return newProcessors;
+    }
+
+    public int processorCount() {
+      return processors.size();
+    }
+    
+    public long lastModifiedIndex() {
+      return lastModifiedIndex;
+    }
+
+    public SortedSet<ProcessorNode> getProcessors() {
+      return Collections.unmodifiableSortedSet(processors);
+    }
+
+    public boolean hasProcessor(String nodeId) {
+      return processors.stream().anyMatch(m -> Objects.equals(m.getId(), nodeId) );
+    }
+  }
+
+  void publishNode() {
+    directory.newDao().put(thisNode.getId(), new ProcessorNode().withId(thisNode.getId()).withStartedAt(new DateTime()));
+  }
+  
+  void unpublishNode() {
+    try {
+      directory.newDao().remove(thisNode.getId());
+    } catch( RuntimeException re ) {
+      logger.warn("could not unpublish process node");
+    }
+  }
+
+  void removeCrashedProcessor( ProcessorNode p ) {
+    try {
+      directory.newDao().remove(p.getId());
+    } catch( Exception e ) {
+      logger.debug("could not remove crashed processor node");
+    }
+  }
+}

--- a/bundle/src/main/java/com/meltmedia/dropwizard/etcd/json/EtcdDirectoryDao.java
+++ b/bundle/src/main/java/com/meltmedia/dropwizard/etcd/json/EtcdDirectoryDao.java
@@ -20,13 +20,13 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import mousio.etcd4j.EtcdClient;
-import mousio.etcd4j.responses.EtcdException;
-import mousio.etcd4j.responses.EtcdKeysResponse;
-
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import mousio.etcd4j.EtcdClient;
+import mousio.etcd4j.responses.EtcdException;
+import mousio.etcd4j.responses.EtcdKeysResponse;
 
 /**
  * A dao for Etcd directories where all values in the directory are of a common type.
@@ -60,7 +60,7 @@ public class EtcdDirectoryDao<T> {
   public Long put(String key, T entry) {
     try {
       return clientSupplier.get().put(directory + "/" + key, mapper.writeValueAsString(entry))
-        .send().get().etcdIndex;
+        .send().get().node.modifiedIndex;
     } catch (Exception e) {
       throw new EtcdDirectoryException(String.format("failed to put key %s", key), e);
     }
@@ -195,7 +195,7 @@ public class EtcdDirectoryDao<T> {
    */
   public Long putDir(String key) {
     try {
-      return clientSupplier.get().putDir(directory + key).send().get().etcdIndex;
+      return clientSupplier.get().putDir(directory + key).send().get().node.modifiedIndex;
     } catch (Exception e) {
       throw new EtcdDirectoryException(String.format("failed to put directory key %s", key), e);
     }
@@ -234,7 +234,7 @@ public class EtcdDirectoryDao<T> {
   public Long put(String key, T value, T previousValue) {
     try {
       return clientSupplier.get().put(directory + "/" + key, mapper.writeValueAsString(value))
-        .prevValue(mapper.writeValueAsString(previousValue)).send().get().etcdIndex;
+        .prevValue(mapper.writeValueAsString(previousValue)).send().get().node.modifiedIndex;
     } catch (Exception e) {
       throw new EtcdDirectoryException(String.format("failed to put key %s with previous value",
         key), e);

--- a/bundle/src/main/java/com/meltmedia/dropwizard/etcd/json/EtcdJson.java
+++ b/bundle/src/main/java/com/meltmedia/dropwizard/etcd/json/EtcdJson.java
@@ -117,14 +117,17 @@ public class EtcdJson {
   public <T> MappedEtcdDirectory<T> newDirectory(String directory, TypeReference<T> type) {
     return new MappedEtcdDirectory<T>(directory, type);
   }
+  
+  public EtcdDirectory newDirectory( String directory ) {
+    return new EtcdDirectory(directory);
+  }
 
-  public class MappedEtcdDirectory<T> {
+  public class MappedEtcdDirectory<T> extends EtcdDirectory {
 
-    private String directory;
     private TypeReference<T> type;
 
     protected MappedEtcdDirectory(String directory, TypeReference<T> type) {
-      this.directory = directory;
+      super(directory);
       this.type = type;
     }
 
@@ -142,16 +145,37 @@ public class EtcdJson {
         .build();
     }
 
+    public EtcdDirectoryDao<T> newDao() {
+      return new EtcdDirectoryDao<T>(clientSupplier, baseDirectory + directory, mapper, type);
+    }
+  }
+  
+  public class EtcdDirectory {
+
+    protected String directory;
+
+    public EtcdDirectory( String directory ) {
+      this.directory = directory;
+    }
+    
     public <U> MappedEtcdDirectory<U> newDirectory(String directory, TypeReference<U> type) {
       return new MappedEtcdDirectory<U>(this.directory + directory, type);
     }
-
-    public EtcdDirectoryDao<T> newDao() {
-      return new EtcdDirectoryDao<T>(clientSupplier, baseDirectory + directory, mapper, type);
+    
+    public EtcdDirectory newDirectory(String directory) {
+      return new EtcdDirectory(this.directory + directory);
+    }
+    
+    public <U> MappedEtcdDirectory<U> map( TypeReference<U> type ) {
+      return new MappedEtcdDirectory<U>(this.directory, type);
     }
 
     public String getName() {
       return this.directory.replaceFirst(".*?([^/]*)\\Z", "$1");
+    }
+    
+    public String getPath() {
+      return this.directory;
     }
   }
 

--- a/bundle/src/main/jsonschema/cluster/processor-node.json
+++ b/bundle/src/main/jsonschema/cluster/processor-node.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Represents a processor that is active in the cluster.",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "startedAt": {
+    	"type": "string",
+      "format": "date-time"
+    }
+  }
+}


### PR DESCRIPTION
Not waiting for etcd state updates after a decision causes wild state changes while nodes enter or exit the cluster.  This change forces the assignment service to wait for changes to be reflected in etcd before more decisions can be made.  It also adds a new document in etcd for each running processor.  This allows the cluster to detect processors that are shutting down and smoothly reassign their processes.

This change adds a new layer of directories when creating processors.  Process documents are no longer stored directly under the process directory, instead a `precesses` subdirectory holds those documents and a `processors` directory holds the documents representing each active processor in the cluster.
